### PR TITLE
add button platform for calibration reset

### DIFF
--- a/esphome/components/bl0940/bl0940.cpp
+++ b/esphome/components/bl0940/bl0940.cpp
@@ -131,6 +131,10 @@ void BL0940::setup() {
     }
   }
 
+  if (this->reset_calibration_button_ != nullptr) {
+    this->reset_calibration_button_->add_on_press_callback([this]() { this->reset_calibration_callback_(); });
+  }
+
   // calculate references based on schematic defaults if not set explicitly
   if (!this->voltage_reference_set_) {
     if (this->tuya_mode_enabled_) {
@@ -196,6 +200,22 @@ float BL0940::calculate_energy_reference_() {
 }
 
 float BL0940::calculate_calibration_value_(float state) { return (100 + state) / 100; }
+
+void BL0940::reset_calibration_callback_() {
+  if (this->current_calibration_ != nullptr && this->current_cal_ != 1) {
+    this->current_calibration_->publish_state(0);
+  }
+  if (this->voltage_calibration_ != nullptr && this->voltage_cal_ != 1) {
+    this->voltage_calibration_->publish_state(0);
+  }
+  if (this->power_calibration_ != nullptr && this->power_cal_ != 1) {
+    this->power_calibration_->publish_state(0);
+  }
+  if (this->energy_calibration_ != nullptr && this->energy_cal_ != 1) {
+    this->energy_calibration_->publish_state(0);
+  }
+  ESP_LOGD(TAG, "external calibration values restored to initial state");
+}
 
 void BL0940::current_calibration_callback_(float state) {
   this->current_cal_ = this->calculate_calibration_value_(state);

--- a/esphome/components/bl0940/bl0940.h
+++ b/esphome/components/bl0940/bl0940.h
@@ -2,9 +2,10 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/datatypes.h"
-#include "esphome/components/uart/uart.h"
+#include "esphome/components/button/button.h"
 #include "esphome/components/number/number.h"
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/components/uart/uart.h"
 
 namespace esphome {
 namespace bl0940 {
@@ -87,6 +88,8 @@ class BL0940 : public PollingComponent, public uart::UARTDevice {
   void set_power_calibration(number::Number *num) { this->power_calibration_ = num; }
   void set_energy_calibration(number::Number *num) { this->energy_calibration_ = num; }
 
+  void set_reset_calibration_button(button::Button *button) { this->reset_calibration_button_ = button; }
+
   void loop() override;
 
   void update() override;
@@ -108,6 +111,8 @@ class BL0940 : public PollingComponent, public uart::UARTDevice {
   number::Number *current_calibration_{nullptr};
   number::Number *power_calibration_{nullptr};
   number::Number *energy_calibration_{nullptr};
+
+  button::Button *reset_calibration_button_{nullptr};
 
   // Max difference between two measurements of the temperature. Used to avoid noise.
   float max_temperature_diff_{0};
@@ -164,6 +169,7 @@ class BL0940 : public PollingComponent, public uart::UARTDevice {
   void voltage_calibration_callback_(float state);
   void power_calibration_callback_(float state);
   void energy_calibration_callback_(float state);
+  void reset_calibration_callback_();
   void recalibrate_();
 };
 

--- a/esphome/components/bl0940/button/__init__.py
+++ b/esphome/components/bl0940/button/__init__.py
@@ -1,0 +1,30 @@
+import esphome.codegen as cg
+from esphome.components import button
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, ENTITY_CATEGORY_CONFIG, ICON_RESTART
+
+from .. import BL0940, CONF_BL0940_ID, bl0940_ns
+
+CalibrationResetButton = bl0940_ns.class_(
+    "CalibrationResetButton", button.Button, cg.Component
+)
+
+CONFIG_SCHEMA = cv.All(
+    button.button_schema(
+        CalibrationResetButton,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        icon=ICON_RESTART,
+    )
+    .extend({cv.Required(CONF_BL0940_ID): cv.use_id(BL0940)})
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    bl0940 = await cg.get_variable(config[CONF_BL0940_ID])
+
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await button.register_button(var, config)
+
+    cg.add(bl0940.set_reset_calibration_button(var))

--- a/esphome/components/bl0940/button/calibration_reset_button.cpp
+++ b/esphome/components/bl0940/button/calibration_reset_button.cpp
@@ -1,0 +1,15 @@
+#include "calibration_reset_button.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+#include "esphome/core/application.h"
+
+namespace esphome {
+namespace bl0940 {
+
+static const char *const TAG = "calibration_reset.button";
+
+void CalibrationResetButton::dump_config() { LOG_BUTTON("", "Calibration Reset Button", this); }
+void CalibrationResetButton::press_action() { ESP_LOGI(TAG, "Resetting calibration defaults..."); }
+
+}  // namespace bl0940
+}  // namespace esphome

--- a/esphome/components/bl0940/button/calibration_reset_button.h
+++ b/esphome/components/bl0940/button/calibration_reset_button.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/button/button.h"
+
+namespace esphome {
+namespace bl0940 {
+
+class CalibrationResetButton : public button::Button, public Component {
+ public:
+  void dump_config() override;
+
+ protected:
+  void press_action() override;
+};
+
+}  // namespace bl0940
+}  // namespace esphome

--- a/esphome/components/bl0940/sensor.py
+++ b/esphome/components/bl0940/sensor.py
@@ -26,6 +26,8 @@ from esphome.const import (
 
 from . import BL0940
 
+AUTO_LOAD = ["button", "number"]
+
 CONF_TUYA_MODE = "tuya_mode"
 
 CONF_READ_COMMAND = "read_command"

--- a/tests/components/bl0940/common.yaml
+++ b/tests/components/bl0940/common.yaml
@@ -4,6 +4,11 @@ uart:
     rx_pin: ${rx_pin}
     baud_rate: 9600
 
+button:
+  - platform: bl0940
+    bl0940_id: test_id
+    name: Cal Reset
+
 sensor:
   - platform: bl0940
     id: test_id


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
