### PR TITLE
make restore_value configurable

### DIFF
--- a/esphome/components/bl0940/bl0940.cpp
+++ b/esphome/components/bl0940/bl0940.cpp
@@ -208,16 +208,16 @@ float BL0940::calculate_calibration_value_(float state) { return (100 + state) /
 void BL0940::reset_calibration_callback_() {
 #ifdef USE_NUMBER
   if (this->current_calibration_ != nullptr && this->current_cal_ != 1) {
-    this->current_calibration_->publish_state(0);
+    this->current_calibration_->make_call().set_value(0).perform();
   }
   if (this->voltage_calibration_ != nullptr && this->voltage_cal_ != 1) {
-    this->voltage_calibration_->publish_state(0);
+    this->voltage_calibration_->make_call().set_value(0).perform();
   }
   if (this->power_calibration_ != nullptr && this->power_cal_ != 1) {
-    this->power_calibration_->publish_state(0);
+    this->power_calibration_->make_call().set_value(0).perform();
   }
   if (this->energy_calibration_ != nullptr && this->energy_cal_ != 1) {
-    this->energy_calibration_->publish_state(0);
+    this->energy_calibration_->make_call().set_value(0).perform();
   }
 #endif
   ESP_LOGD(TAG, "external calibration values restored to initial state");

--- a/esphome/components/bl0940/number/__init__.py
+++ b/esphome/components/bl0940/number/__init__.py
@@ -5,9 +5,9 @@ from esphome.const import (
     CONF_MAX_VALUE,
     CONF_MIN_VALUE,
     CONF_MODE,
+    CONF_RESTORE_VALUE,
     CONF_STEP,
     ENTITY_CATEGORY_CONFIG,
-    ICON_PERCENT,
     UNIT_PERCENT,
 )
 
@@ -39,13 +39,13 @@ CALIBRATION_SCHEMA = cv.All(
         CalibrationNumber,
         entity_category=ENTITY_CATEGORY_CONFIG,
         unit_of_measurement=UNIT_PERCENT,
-        icon=ICON_PERCENT,
     )
     .extend(
         {
             cv.Optional(CONF_MAX_VALUE, default=10): cv.float_,
             cv.Optional(CONF_MIN_VALUE, default=-10): cv.float_,
             cv.Optional(CONF_STEP, default=0.1): cv.positive_float,
+            cv.Optional(CONF_RESTORE_VALUE): cv.boolean,
         }
     )
     .extend(cv.polling_component_schema("never")),
@@ -87,4 +87,6 @@ async def to_code(config):
             )
             await cg.register_component(var, conf)
 
+            if CONF_RESTORE_VALUE in config:
+                cg.add(var.set_restore_value(config[CONF_RESTORE_VALUE]))
             cg.add(getattr(bl0940, setter_method)(var))

--- a/esphome/components/bl0940/number/calibration_number.cpp
+++ b/esphome/components/bl0940/number/calibration_number.cpp
@@ -11,9 +11,17 @@ void CalibrationNumber::setup() {
     return;
 
   float value;
-  this->pref_ = global_preferences->make_preference<float>(this->get_object_id_hash());
-  if (!this->pref_.load(&value)) {
+  if (!this->restore_value_) {
     value = this->initial_value_;
+  } else {
+    this->pref_ = global_preferences->make_preference<float>(this->get_object_id_hash());
+    if (!this->pref_.load(&value)) {
+      if (!std::isnan(this->initial_value_)) {
+        value = this->initial_value_;
+      } else {
+        value = this->traits.get_min_value();
+      }
+    }
   }
   this->publish_state(value);
 }
@@ -31,7 +39,8 @@ void CalibrationNumber::update() {
 
 void CalibrationNumber::control(float value) {
   this->publish_state(value);
-  this->pref_.save(&value);
+  if (this->restore_value_)
+    this->pref_.save(&value);
 }
 
 void CalibrationNumber::dump_config() {

--- a/esphome/components/bl0940/number/calibration_number.h
+++ b/esphome/components/bl0940/number/calibration_number.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "esphome/components/number/number.h"
-#include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
 
@@ -15,9 +14,12 @@ class CalibrationNumber : public number::Number, public PollingComponent {
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
+  void set_restore_value(bool restore_value) { this->restore_value_ = restore_value; }
+
  protected:
   void control(float value) override;
   float initial_value_{0};
+  bool restore_value_{true};
   optional<std::function<optional<float>()>> f_;
 
   ESPPreferenceObject pref_;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
